### PR TITLE
BOSA21Q1-200 Drawing: error in display on result page

### DIFF
--- a/app/models/decidim/casting_result.rb
+++ b/app/models/decidim/casting_result.rb
@@ -23,7 +23,7 @@ module Decidim
 
 
     def candidates_without_substitutes
-      casting.amount_of_candidates - statistics.dig('total_candidates')
+      total_candidates - total_substitutes
     end
 
     def is_expected_result?


### PR DESCRIPTION
## Description
- What?
- - Drawing: error in display on result page
- Why?
- - In total, as a result, I got 42 participants & 16 substitutes. So there is an error, it should be written "Participants without substitutes 26"
- How?
- - Change the method candidates_without_substitutes. 

## Ticket
[BOSA21Q1-200](https://belighted.atlassian.net/browse/BOSA21Q1-200?atlOrigin=eyJpIjoiN2Q0YWQzN2U3YWJiNGRmYzkzNGIwMGY5ODliM2Y5YWQiLCJwIjoiaiJ9)

## Type of changes

- [ ]  Docs changes
- [ ]  Refactoring
- [ ]  Dependency upgrade
- [x]  Bug fix
- [ ]  New feature
- [ ]  Breaking changes